### PR TITLE
Implement News Resources for MCP

### DIFF
--- a/integration/mcp_news_resource.test.ts
+++ b/integration/mcp_news_resource.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+import { registerNewsResource } from '../src/mcp/resources/news';
+
+describe('MCP News Resource', () => {
+  it('should register a resource named news with correct URI pattern', async () => {
+    const mockServer = {
+      resource: vi.fn()
+    };
+    const mockHnapi = {};
+
+    registerNewsResource(mockServer, mockHnapi as any);
+
+    expect(mockServer.resource).toHaveBeenCalledWith(
+      "news",
+      "hn://{topic}",
+      expect.any(Function)
+    );
+  });
+
+  it('should fetch news stories when the resource handler is called', async () => {
+    const mockServer = {
+      resource: vi.fn()
+    };
+    const mockStories = [{ id: 1, title: 'Story 1' }];
+    const mockHnapi = {
+      news: vi.fn().mockResolvedValue(mockStories)
+    };
+
+    registerNewsResource(mockServer, mockHnapi as any);
+
+    const handler = mockServer.resource.mock.calls[0][2];
+
+    const mockUri = new URL('hn://news');
+    const result = await handler(mockUri, { topic: 'news' });
+
+    expect(mockHnapi.news).toHaveBeenCalledWith({ page: 1 });
+    expect(result).toEqual({
+      contents: [{
+        uri: mockUri.href,
+        text: JSON.stringify(mockStories, null, 2),
+        mimeType: "application/json"
+      }]
+    });
+  });
+
+  it('should handle pagination via page query parameter', async () => {
+    const mockServer = {
+      resource: vi.fn()
+    };
+    const mockStories = [{ id: 2, title: 'Story 2' }];
+    const mockHnapi = {
+      news: vi.fn().mockResolvedValue(mockStories)
+    };
+
+    registerNewsResource(mockServer, mockHnapi as any);
+
+    const handler = mockServer.resource.mock.calls[0][2];
+
+    const mockUri = new URL('hn://news?page=2');
+    const result = await handler(mockUri, { topic: 'news' });
+
+    expect(mockHnapi.news).toHaveBeenCalledWith({ page: 2 });
+    expect(result.contents[0].uri).toContain('page=2');
+  });
+
+  it('should fetch other topics like newest', async () => {
+    const mockServer = {
+      resource: vi.fn()
+    };
+    const mockStories = [{ id: 3, title: 'Newest Story' }];
+    const mockHnapi = {
+      newest: vi.fn().mockResolvedValue(mockStories)
+    };
+
+    registerNewsResource(mockServer, mockHnapi as any);
+
+    const handler = mockServer.resource.mock.calls[0][2];
+
+    const mockUri = new URL('hn://newest');
+    await handler(mockUri, { topic: 'newest' });
+
+    expect(mockHnapi.newest).toHaveBeenCalledWith({ page: 1 });
+  });
+
+  it('should throw error for invalid topics', async () => {
+    const mockServer = {
+      resource: vi.fn()
+    };
+    const mockHnapi = {};
+
+    registerNewsResource(mockServer, mockHnapi as any);
+
+    const handler = mockServer.resource.mock.calls[0][2];
+
+    const mockUri = new URL('hn://invalid');
+    await expect(handler(mockUri, { topic: 'invalid' })).rejects.toThrow('Invalid topic: invalid');
+  });
+});

--- a/src/mcp/resources/index.ts
+++ b/src/mcp/resources/index.ts
@@ -1,5 +1,6 @@
 import { Api } from '../../api';
 import { registerUserResource } from './user';
+import { registerNewsResource } from './news';
 
 /**
  * Register all MCP resources.
@@ -9,4 +10,5 @@ import { registerUserResource } from './user';
  */
 export function registerAllResources(server: any, hnapi: Api) {
   registerUserResource(server, hnapi);
+  registerNewsResource(server, hnapi);
 }

--- a/src/mcp/resources/news.ts
+++ b/src/mcp/resources/news.ts
@@ -1,0 +1,35 @@
+import { Api } from '../../api';
+
+/**
+ * Register the News resource with the MCP server.
+ * Exposes stories (news, newest, ask, show, jobs) via hn://{topic}
+ *
+ * @param server - The McpServer instance
+ * @param hnapi - The Hacker News API instance
+ */
+export function registerNewsResource(server: any, hnapi: Api) {
+  server.resource(
+    "news",
+    "hn://{topic}",
+    async (uri: any, { topic }: any) => {
+      const validTopics = ['news', 'newest', 'ask', 'show', 'jobs'];
+      if (!validTopics.includes(topic)) {
+        throw new Error(`Invalid topic: ${topic}`);
+      }
+
+      // uri is a URL object from @modelcontextprotocol/sdk
+      const pageStr = uri.searchParams?.get("page") || "1";
+      const page = parseInt(pageStr, 10);
+
+      const stories = await (hnapi as any)[topic]({ page });
+
+      return {
+        contents: [{
+          uri: uri.href,
+          text: JSON.stringify(stories, null, 2),
+          mimeType: "application/json"
+        }]
+      };
+    }
+  );
+}


### PR DESCRIPTION
Exposed Hacker News story categories (news, newest, ask, show, jobs) as MCP resources using the URI pattern `hn://{topic}`. The implementation supports an optional `page` query parameter for pagination and has been verified with integration tests.

---
*PR created automatically by Jules for task [3390867593144848767](https://jules.google.com/task/3390867593144848767) started by @davideast*