### PR TITLE
Add Item Resource to MCP

### DIFF
--- a/integration/mcp_item_resource.test.ts
+++ b/integration/mcp_item_resource.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { registerItemResource } from '../src/mcp/resources/item';
+
+describe('MCP Item Resource', () => {
+  it('should register a resource named item with correct URI pattern', async () => {
+    const mockServer = {
+      resource: vi.fn()
+    };
+    const mockHnapi = {};
+
+    registerItemResource(mockServer, mockHnapi as any);
+
+    expect(mockServer.resource).toHaveBeenCalledWith(
+      "item",
+      "hn://item/{id}",
+      expect.any(Function)
+    );
+  });
+
+  it('should fetch item data when the resource handler is called', async () => {
+    const mockServer = {
+      resource: vi.fn()
+    };
+    const mockItem = { id: 123, title: 'Test Item' };
+    const mockHnapi = {
+      item: vi.fn().mockResolvedValue(mockItem)
+    };
+
+    registerItemResource(mockServer, mockHnapi as any);
+
+    const handler = mockServer.resource.mock.calls[0][2];
+
+    const mockUri = { href: 'hn://item/123' };
+    const result = await handler(mockUri, { id: '123' });
+
+    expect(mockHnapi.item).toHaveBeenCalledWith(123);
+    expect(result).toEqual({
+      contents: [{
+        uri: 'hn://item/123',
+        text: JSON.stringify(mockItem, null, 2),
+        mimeType: "application/json"
+      }]
+    });
+  });
+
+  it('should throw error when item is not found', async () => {
+    const mockServer = {
+      resource: vi.fn()
+    };
+    const mockHnapi = {
+      item: vi.fn().mockResolvedValue(null)
+    };
+
+    registerItemResource(mockServer, mockHnapi as any);
+
+    const handler = mockServer.resource.mock.calls[0][2];
+
+    const mockUri = { href: 'hn://item/999' };
+    await expect(handler(mockUri, { id: '999' })).rejects.toThrow('Item 999 not found');
+  });
+});

--- a/src/mcp/resources/index.ts
+++ b/src/mcp/resources/index.ts
@@ -1,6 +1,7 @@
 import { Api } from '../../api';
 import { registerUserResource } from './user';
 import { registerNewsResource } from './news';
+import { registerItemResource } from './item';
 
 /**
  * Register all MCP resources.
@@ -11,4 +12,5 @@ import { registerNewsResource } from './news';
 export function registerAllResources(server: any, hnapi: Api) {
   registerUserResource(server, hnapi);
   registerNewsResource(server, hnapi);
+  registerItemResource(server, hnapi);
 }

--- a/src/mcp/resources/item.ts
+++ b/src/mcp/resources/item.ts
@@ -1,0 +1,29 @@
+import { Api } from '../../api';
+
+/**
+ * Register the Item resource with the MCP server.
+ * Exposes individual items via hn://item/{id}
+ *
+ * @param server - The McpServer instance
+ * @param hnapi - The Hacker News API instance
+ */
+export function registerItemResource(server: any, hnapi: Api) {
+  server.resource(
+    "item",
+    "hn://item/{id}",
+    async (uri: any, { id }: any) => {
+      const itemId = parseInt(id, 10);
+      const item = await hnapi.item(itemId);
+      if (!item) {
+        throw new Error(`Item ${id} not found`);
+      }
+      return {
+        contents: [{
+          uri: uri.href,
+          text: JSON.stringify(item, null, 2),
+          mimeType: "application/json"
+        }]
+      };
+    }
+  );
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -94,14 +94,6 @@ export function getNewsAndStuff(hnapi: Api) {
  * the user.
  * @param firebaseApp
  */
-// TODO [MCP-TASK]: Create Item Resource
-// Type: Resource
-// Complexity: Low
-// Context: Expose individual items and comments.
-// Strategy:
-// 1. Create `src/mcp/resources/item.ts`.
-// 2. Register resource `hn://item/{id}`.
-// 3. Use `hnapi.item(id)` to fetch data.
 export function getItemAndComments(hnapi: Api) {
   return async (req: any, res: any) => {
     const itemId = req.params[0];


### PR DESCRIPTION
This change adds the Item resource to the MCP server, exposing individual Hacker News items and their comments via the `hn://item/{id}` URI pattern. It includes:
- Implementation of `registerItemResource` in `src/mcp/resources/item.ts`.
- Registration of the new resource in `src/mcp/resources/index.ts`.
- An integration test file `integration/mcp_item_resource.test.ts` to verify functionality.
- Cleanup of the corresponding TODO in `src/server.ts`.


---
*PR created automatically by Jules for task [14595335830847684907](https://jules.google.com/task/14595335830847684907) started by @davideast*