### PR TITLE
Implement MCP News Resources and Refactor Naming Convention

### DIFF
--- a/integration/mcp_item_resource.test.ts
+++ b/integration/mcp_item_resource.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { itemResource } from '../src/mcp/resources/item.resource';
+import { itemResource } from '../src/mcp/resources/item';
 
 describe('MCP Item Resource', () => {
   it('should register a resource named item with correct URI pattern', async () => {

--- a/integration/mcp_news_resource.test.ts
+++ b/integration/mcp_news_resource.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { newsResource } from '../src/mcp/resources/news.resource';
+import { newsResource } from '../src/mcp/resources/news';
 
 describe('MCP News Resource', () => {
   it('should register a resource named news with correct URI pattern', async () => {

--- a/integration/mcp_resource.test.ts
+++ b/integration/mcp_resource.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { userResource } from '../src/mcp/resources/user.resource';
+import { userResource } from '../src/mcp/resources/user';
 
 describe('MCP User Resource', () => {
   it('should register a resource named user with correct URI pattern', async () => {

--- a/src/mcp/resources/item.ts
+++ b/src/mcp/resources/item.ts
@@ -1,4 +1,4 @@
-import { Api } from '../../api/index';
+import { Api } from '../../api/types';
 import { McpResource } from '../resource';
 
 export const itemResource: McpResource = {

--- a/src/mcp/resources/news.ts
+++ b/src/mcp/resources/news.ts
@@ -1,4 +1,4 @@
-import { Api } from '../../api/index';
+import { Api } from '../../api/types';
 import { McpResource } from '../resource';
 
 export const newsResource: McpResource = {
@@ -16,7 +16,7 @@ export const newsResource: McpResource = {
         const pageStr = uri.searchParams?.get("page") || "1";
         const page = parseInt(pageStr, 10);
 
-        const stories = await (hnapi as any)[topic]({ page });
+        const stories = await hnapi[topic]({ page });
 
         return {
           contents: [{

--- a/src/mcp/resources/user.ts
+++ b/src/mcp/resources/user.ts
@@ -1,4 +1,4 @@
-import { Api } from '../../api/index';
+import { Api } from '../../api/types';
 import { McpResource } from '../resource';
 
 export const userResource: McpResource = {

--- a/src/server.ts
+++ b/src/server.ts
@@ -62,14 +62,6 @@ export function getIndex(hnapi: Api) {
  * through the ?page query param.
  * @param firebaseApp
  */
-// TODO [MCP-TASK]: Create News Resources
-// Type: Resource
-// Complexity: Low
-// Context: Expose stories (news, ask, jobs, etc.) to LLMs.
-// Strategy:
-// 1. Create `src/mcp/resources/news.ts`.
-// 2. Register resources `hn://{topic}` where topic is 'news', 'newest', 'ask', 'show', 'jobs'.
-// 3. Use `hnapi[topic]({ page })` to fetch data.
 export function getNewsAndStuff(hnapi: Api) {
   return async (req: any, res: any) => {
     // "news" | "ask" | "jobs" | "show" etc...


### PR DESCRIPTION
This change implements the MCP News Resources as requested. It also refactors the MCP resource naming convention for consistency and updates the tests and imports accordingly. The TODO in `src/server.ts` has been removed. All MCP integration tests pass.

---
*PR created automatically by Jules for task [4583005597514276258](https://jules.google.com/task/4583005597514276258) started by @davideast*