### PR TITLE
🔒 fix: race condition in global JSON configuration

### DIFF
--- a/integration/security_fix.test.ts
+++ b/integration/security_fix.test.ts
@@ -47,7 +47,7 @@ describe('Security Fix: Race Condition in Global Configuration', () => {
   it('should return pretty-printed JSON for the index page', async () => {
     const response = await request(app).get('/');
     expect(response.status).toBe(200);
-    // Index page is forced to be pretty by prettyIndex middleware
+    // Index page is forced to be pretty by default in prettyPrint middleware
     expect(response.text).toContain('\n');
     expect(response.text).toContain('  "');
   });

--- a/src/server.ts
+++ b/src/server.ts
@@ -175,7 +175,11 @@ function prettyPrint() {
     const app = req.app;
 
     res.json = function(obj: any) {
-      const spaces = typeof req.query.print === 'undefined' ? 0 : 2;
+      const print = this.req.query.print;
+      // Index page (/) is pretty-printed by default
+      const isIndex = this.req.path === '/' || this.req.path === '';
+      const spaces = (typeof print === 'undefined' && !isIndex) ? 0 : 2;
+
       const replacer = app.get('json replacer');
       const body = JSON.stringify(obj, replacer, spaces);
       this.set('Content-Type', 'application/json');
@@ -183,11 +187,15 @@ function prettyPrint() {
     };
 
     res.jsonp = function(obj: any) {
-      const spaces = typeof req.query.print === 'undefined' ? 0 : 2;
+      const print = this.req.query.print;
+      // Index page (/) is pretty-printed by default
+      const isIndex = this.req.path === '/' || this.req.path === '';
+      const spaces = (typeof print === 'undefined' && !isIndex) ? 0 : 2;
+
       const replacer = app.get('json replacer');
       let body = JSON.stringify(obj, replacer, spaces);
       const callbackName = app.get('jsonp callback name') || 'callback';
-      let callback = req.query[callbackName];
+      let callback = this.req.query[callbackName];
 
       if (Array.isArray(callback)) {
         callback = callback[0];
@@ -213,15 +221,6 @@ function prettyPrint() {
 
     next();
   };
-}
-
-function prettyIndex() {
-  return (req: any, res: any, next: Function) => {
-    if (req.path === '/') {
-      req.query.print = 'pretty'
-    }
-    next();
-  }
 }
 
 // Define RequestHandler type locally to match express usage
@@ -266,7 +265,6 @@ export function createExpressApp(config: ApiConfig) {
   // Configure middleware
   if (config.useCompression) { expressApp.use(compression()); }
   expressApp.use(cacheControl(config));
-  expressApp.use(prettyIndex());
   expressApp.use(prettyPrint());
 
   if (config.offline) { expressApp.use(express.static(`${__dirname}/offline/static`)); }


### PR DESCRIPTION
🎯 **What:** The `prettyPrint` middleware was modifying the global Express application configuration (`app.set('json spaces', ...)`) on every request. This caused a race condition where concurrent requests would overwrite each other's formatting settings.

⚠️ **Risk:** Requests could receive incorrectly formatted JSON (minified instead of pretty, or vice versa) if another request arrived simultaneously. This lack of request isolation is a security and reliability concern in global state management.

🛡️ **Solution:** The fix removes all calls to `req.app.set` within request handlers. Instead, the `prettyPrint` middleware now overrides `res.json` and `res.jsonp` specifically for the current response. These overridden methods use a local variable to determine indentation, ensuring complete isolation between requests. The implementation of `res.jsonp` follows Express security best practices, including callback name sanitization.

✅ **Verification:**
- Logic verified with a standalone script replicating the middleware behavior.
- Added a new integration test `integration/security_fix.test.ts` covering default minification, `print=pretty`, and JSONP scenarios.
- Positive code review received.

---
*PR created automatically by Jules for task [12788037336212021197](https://jules.google.com/task/12788037336212021197) started by @davideast*