### PR TITLE
⚡ Parallelize sequential page fetching in getStories

### DIFF
--- a/src/offline/build.ts
+++ b/src/offline/build.ts
@@ -16,18 +16,29 @@ export interface GetStoriesOptions {
 export async function getStories(
   { hnapi, topic, opts, max, acc = [] }: GetStoriesOptions,
   onStories?: (stories: Story[], sum: Story[], page: number) => void): Promise<Story[]> {
-  const news = await hnapi[topic](opts);
-  const sum = acc.concat(news);
-  const nextPage = opts.page + 1;
-  if(onStories !== undefined) {
-    onStories(news, sum, opts.page);
-  }
-  if(opts.page >= max) {
-    return sum;
-  }
-  opts = { page: nextPage };
 
-  return getStories({ hnapi, topic, opts, max, acc: sum }, onStories);
+  const pages: number[] = [];
+  for (let i = opts.page; i <= max; i++) {
+    pages.push(i);
+  }
+
+  const results = await Promise.all(pages.map(async (page) => {
+    const stories = await hnapi[topic]({ ...opts, page });
+    return { stories, page };
+  }));
+
+  // Sort by page number to ensure consistent accumulation and callback order
+  results.sort((a, b) => a.page - b.page);
+
+  let sum = [...acc];
+  for (const result of results) {
+    sum = sum.concat(result.stories);
+    if (onStories !== undefined) {
+      onStories(result.stories, sum, result.page);
+    }
+  }
+
+  return sum;
 }
 
 /**


### PR DESCRIPTION
### ⚡ Performance Optimization: Parallel Page Fetching

#### 💡 What:
Refactored the `getStories` function in `src/offline/build.ts` to replace its sequential recursive implementation with a parallel approach using `Promise.all`.

#### 🎯 Why:
Hacker News topics like `news` and `newest` require fetching 10 pages of data. The original implementation fetched these one after another, waiting for each request to complete before starting the next. This created a significant and unnecessary bottleneck during offline builds and publishing tasks.

#### 📊 Measured Improvement:
- **Theoretical Speedup:** For topics with 10 pages (like `news`), the execution time is reduced from approximately `10 * T` (where T is average request time) to `1 * T_slowest`. This represents a **~10x theoretical speedup** for data-heavy topics.
- **Safety:** The implementation preserves the original `onStories` callback signature and ensures that results are accumulated and reported in the correct sequential order (Page 1 -> Page 2 -> ...) despite being fetched in parallel.
- **Robustness:** Added preservation of all properties in the `opts` object during page requests, which was previously lost in recursive calls.

Direct benchmark measurement was attempted in the sandbox but was blocked by environment/dependency issues; however, the architectural improvement is a standard best practice for network-bound tasks.

---
*PR created automatically by Jules for task [1976685944946140815](https://jules.google.com/task/1976685944946140815) started by @davideast*