### PR TITLE
🧹 Remove unused variables in integration/offline.test.ts

### DIFF
--- a/integration/offline.test.ts
+++ b/integration/offline.test.ts
@@ -33,9 +33,7 @@ describe('Integration: Offline & Publisher', () => {
   });
 
   it('should build offline files correctly (limited scope)', async () => {
-    const app = initializeApp({ firebaseAppName: `test-offline-${Date.now()}` });
-    const hnapi = api(app);
-
+    initializeApp({ firebaseAppName: `test-offline-${Date.now()}` });
     // We use a spy or just verify file existence
     // We rely on MAX_PAGES=1 modification to keep it fast
 
@@ -52,8 +50,7 @@ describe('Integration: Offline & Publisher', () => {
   });
 
   it('should publish files to specified destination', async () => {
-    const app = initializeApp({ firebaseAppName: `test-publish-${Date.now()}` });
-
+    initializeApp({ firebaseAppName: `test-publish-${Date.now()}` });
     // Publisher uses CronJob but we can check the task logic or just run the task?
     // publisher returns { _job, start, stop, isRunning }
     // The task logic is private in `createPublishTask`.


### PR DESCRIPTION
This change removes unused variables `hnapi` and `app` from the `integration/offline.test.ts` file. These variables were initialized but never used in the tests. Removing them improves code clarity and maintainability. The calls to `initializeApp` are preserved because they perform necessary side-effectful setup for the Firebase SDK used in the integration tests.

🎯 **What:** Removed unused variables `hnapi` and `app` in `integration/offline.test.ts`.
💡 **Why:** To improve code maintainability and readability by eliminating dead code.
✅ **Verification:** Verified by reading the file and performing a compilation check using `bun build`.
✨ **Result:** Cleaner test code with no impact on test functionality.

---
*PR created automatically by Jules for task [4877033448680122971](https://jules.google.com/task/4877033448680122971) started by @davideast*